### PR TITLE
修改材料奖励房出现概率

### DIFF
--- a/Scripts/RoomLogic.lua
+++ b/Scripts/RoomLogic.lua
@@ -4153,7 +4153,7 @@ function ChooseNextRewardStore( run )
 		metaProgressChance = metaProgressChance + (run.Hero.TargetMetaRewardsAdjustSpeed * (targetMetaRewardsRatio - currentMetaProgressRatio))
 	end
 	--DebugPrint({ Text = "metaProgressChance = "..metaProgressChance })
-	if RandomChance( metaProgressChance ) then
+	if RandomChance( 0 ) then
 		rewardStoreName = "MetaProgress"
 	else
 		rewardStoreName = "RunProgress"


### PR DESCRIPTION
将metaProgressChance改为0表示没有材料奖励房
改为1表示全是材料奖励房
改为0.1则表示材料奖励房出现概率为10%