### PR TITLE
增加悟性基础值

### DIFF
--- a/Scripts/MetaUpgradeData.lua
+++ b/Scripts/MetaUpgradeData.lua
@@ -17,7 +17,7 @@ MetaUpgradeSwapGameStateRequirement =
 
 MetaUpgradeCostData = 
 {
-	StartingMetaUpgradeLimit = 10,		-- Base metaupgrade 'MEM' limit
+	StartingMetaUpgradeLimit = 100,		-- Base metaupgrade 'MEM' limit
 	MetaUpgradeLevelData = 
 	{
 		{ CostIncrease = 2, ResourceCost = { MemPointsCommon = 40 }},


### PR DESCRIPTION
StartingMetaUpgradeLimit表示没有任何升级下的悟性基础值, 在游戏中默认是10, 修改这个值可以提高悟性上限