### PR TITLE
银白之颅回收时间

### DIFF
--- a/Scripts/ConsumableData.lua
+++ b/Scripts/ConsumableData.lua
@@ -309,8 +309,8 @@ ConsumableData =
 
 		CompleteObjective = "WeaponLobPickup",
 
-		MagnetismEscalateDelay = 10.0,
-		MagnetismHintRemainingTime = 5.0,
+		MagnetismEscalateDelay = 1,
+		MagnetismHintRemainingTime = 0.5,
 		MagnetismEscalateAmount = 99000,
 	},
 


### PR DESCRIPTION
MagnetismEscalateDelay 是总回收时间,默认是10, 
另外还需要修改MagnetismHintRemainingTime,这个是倒计时出现后等待的时间, 这个必须比总回收时间要少