### PR TITLE
必然生成扎格列欧斯挑战入口

### DIFF
--- a/Scripts/EncounterSets.lua
+++ b/Scripts/EncounterSets.lua
@@ -436,7 +436,7 @@ EncounterSets =
 				{
 					PathFalse = { "CurrentRun", "RoomCountCache", "C_Boss01" }
 				},
-				ChanceToPlay = 0.40,
+				ChanceToPlay = 1.0,
 			},
 		},
 		{
@@ -813,4 +813,5 @@ EncounterSets =
 		"EliteChallengeSwitch_MaxMana",
 		"EliteChallengeSwitch_MaxMana",
 	},
+
 }


### PR DESCRIPTION
调整商店扎格列欧斯挑战入口遭遇事件几率为 1.0，即中途商店满足其他条件时必然生成扎格列欧斯挑战入口。
